### PR TITLE
Inheritance SkillSystem

### DIFF
--- a/ACPL_SkillSystem/cfgVehicles.hpp
+++ b/ACPL_SkillSystem/cfgVehicles.hpp
@@ -1,7 +1,7 @@
 class Logic;
 class Module_F: Logic {
-	class ArgumentsBaseUnits {};
-	class ModuleDescription {};
+	class ArgumentsBaseUnits;
+	class ModuleDescription;
 };
 
 #include "modules\cfgSettings.hpp"


### PR DESCRIPTION
Uwaga na dziedziczenie w cfg!
`Klasa {};` - czyści klasę
`Klasa; `- pozwala z niej dziedziczyć, nie zmieniając jej stanu